### PR TITLE
Move padding from index.html to CSS

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -28,8 +28,8 @@ task 'clean', 'Removes distribution', ->
 
 task 'dist', 'Build a distribution', ->
   console.log "Build distribution in ./dist"
-  fs.mkdirSync('dist') if not path.existsSync('dist')
-  fs.mkdirSync('dist/lib') if not path.existsSync('dist/lib')
+  fs.mkdirSync('dist') if not fs.existsSync('dist')
+  fs.mkdirSync('dist/lib') if not fs.existsSync('dist/lib')
 
   appContents = new Array remaining = sourceFiles.length
   for file, index in sourceFiles then do (file, index) ->
@@ -97,8 +97,7 @@ task 'dist', 'Build a distribution', ->
     # Someone who knows CoffeeScript should make this more Coffee-licious
     console.log '   : Compiling LESS...'
 
-    if !fs.existsSync 'src/main/html/css'
-      fs.mkdirSync 'src/main/html/css'
+    fs.mkdirSync 'src/main/html/css' if not fs.existsSync 'src/main/html/css'
 
     lessFile 'screen.less'
     lessFile 'reset.less'

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -83,6 +83,6 @@
 </div>
 
 <div id="message-bar" class="swagger-ui-wrap">&nbsp;</div>
-<div id="swagger-ui-container" class="swagger-ui-wrap" style="padding: 20px"></div>
+<div id="swagger-ui-container" class="swagger-ui-wrap"></div>
 </body>
 </html>

--- a/src/main/less/specs.less
+++ b/src/main/less/specs.less
@@ -4,6 +4,10 @@
   margin-right: auto;
 }
 
+.standalone #swagger-ui-container {
+  padding: 20px;
+}
+
 .swagger-section {
 
     .message-fail {


### PR DESCRIPTION
Improve the solution introduced by 0c1c47ea and move the extra padding from "style" attribute to a CSS file where it belongs.

Connect to strongloop-internal/scrum-loopback#112

/to @raymondfeng @ritch could one of you please review?
