### PR TITLE
fix linting error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var pack = require('./package');
 var path = require('path');
 


### PR DESCRIPTION
Since 'npm test' is configured to require linting to pass, this little
change is necessary for CI to even attempt to run the tests themselves.

Connect to strongloop-internal/scrum-nodeops#901
