### PR TITLE
reduce endpoint rendering time, page freeze issue

### DIFF
--- a/src/main/javascript/doc.js
+++ b/src/main/javascript/doc.js
@@ -88,9 +88,7 @@ window.Docs = {
 
 		// If shebang has an operation nickname in it..
 		// e.g. /docs/#!/words/get_search
-		var fragments = $.param.fragment().split('/');
-		fragments.shift(); // get rid of the bang
-
+		var fragments = Docs.getFragments();
 		switch (fragments.length) {
 			case 1:
         if (fragments[0].length > 0) { // prevent matching "#/"
@@ -118,6 +116,12 @@ window.Docs = {
 				break;
 		}
 
+	},
+
+	getFragments : function(){
+		var fragments = $.param.fragment().split('/');
+		fragments.shift(); // get rid of the bang
+		return fragments;
 	},
 
 	toggleEndpointListForResource: function(resource) {

--- a/src/main/javascript/view/ResourceView.js
+++ b/src/main/javascript/view/ResourceView.js
@@ -11,41 +11,51 @@ SwaggerUi.Views.ResourceView = Backbone.View.extend({
     if (this.model.description) {
       this.model.summary = this.model.description;
     }
+
+    var fragments = Docs.getFragments();
+    if (fragments.length) {
+      this.selectedResource = fragments;
+    }
   },
 
-  render: function(){
+  render: function() {
     var methods = {};
 
 
     $(this.el).html(Handlebars.templates.resource(this.model));
 
-    // Render each operation
+    // save each operation to render on click of model
+    var modelId = this.model.id;
+    this.operationsObj = this.operationsObj || {};
+    this.operationsObj[modelId] = {
+      operations: []
+    };
     for (var i = 0; i < this.model.operationsArray.length; i++) {
       var operation = this.model.operationsArray[i];
       var counter = 0;
       var id = operation.nickname;
-
       while (typeof methods[id] !== 'undefined') {
         id = id + '_' + counter;
         counter += 1;
       }
-
       methods[id] = operation;
-
       operation.nickname = id;
-      operation.parentId = this.model.id;
-      this.addOperation(operation);
+      operation.parentId = modelId;
+      if (this.selectedResource && this.selectedResource[0] === modelId) {
+        this.addOperation(operation);
+        delete this.operationsObj[modelId];
+      } else {
+        this.operationsObj[modelId].operations.push(operation);
+      }
     }
 
     $('.toggleEndpointList', this.el).click(this.callDocs.bind(this, 'toggleEndpointListForResource'));
     $('.collapseResource', this.el).click(this.callDocs.bind(this, 'collapseOperationsForResource'));
     $('.expandResource', this.el).click(this.callDocs.bind(this, 'expandOperationsForResource'));
-
     return this;
   },
 
   addOperation: function(operation) {
-
     operation.number = this.number;
 
     // Render an operation and add it to operations li
@@ -68,6 +78,17 @@ SwaggerUi.Views.ResourceView = Backbone.View.extend({
 
   callDocs: function(fnName, e) {
     e.preventDefault();
+    var modelId = this.model.id;
+    this.renderResources(modelId);
     Docs[fnName](e.currentTarget.getAttribute('data-id'));
+  },
+  renderResources: function(modelId) {
+    if (this.operationsObj && this.operationsObj[modelId]) {
+      var operations = this.operationsObj[modelId].operations;
+      operations.forEach(function(d) {
+        this.addOperation(d);
+      }.bind(this));
+      delete this.operationsObj[modelId];
+    }
   }
 });


### PR DESCRIPTION
In case of more than 100 model and each model having 8-10 end points on an average, landing page of swagger used to take more time to render. Also after loading home page, it used to be non responsive for the next 10 seconds. I made few changes, so now, not all the endpoints will not be rendered initially. The same will be rendered after click on any model.
